### PR TITLE
Add PostgreSQL (pgsql) support to DBI and DataTables

### DIFF
--- a/src/pda/DBI.php
+++ b/src/pda/DBI.php
@@ -46,16 +46,20 @@ class DBI
      */
     protected function DBISet(array $connection, $database)
     {
-        $this->dbType = $connection[$database]['dbType'];
-        $this->host = $connection[$database]['host'];
-        $this->port = $connection[$database]['port'];
+        $dbConfig = isset($connection[$database]) ? $connection[$database] : [];
 
-        $this->dbName = $connection[$database]['dbName'];
-        $this->username = $connection[$database]['user'];
-        $this->password = $connection[$database]['pass'];
+        $this->dbType = isset($dbConfig['dbType']) ? $dbConfig['dbType'] : getenv('DB_TYPE');
+        $this->host = isset($dbConfig['host']) ? $dbConfig['host'] : getenv('DB_HOST');
+        $this->port = isset($dbConfig['port']) ? $dbConfig['port'] : getenv('DB_PORT');
 
-        if (isset($connection[$database]['driver'])) {
-            $this->driver = $connection[$database]['driver'];
+        $this->dbName = isset($dbConfig['dbName']) ? $dbConfig['dbName'] : getenv('DB_NAME');
+        $this->username = isset($dbConfig['user']) ? $dbConfig['user'] : getenv('DB_USER');
+        $this->password = isset($dbConfig['pass']) ? $dbConfig['pass'] : getenv('DB_PASS');
+
+        if (isset($dbConfig['driver'])) {
+            $this->driver = $dbConfig['driver'];
+        } elseif (getenv('DB_DRIVER')) {
+            $this->driver = getenv('DB_DRIVER');
         }
     }
 
@@ -97,6 +101,9 @@ class DBI
                     $pdoConnection = "sqlsrv:Server=$this->host,$this->port;Database=$this->dbName";
                 }
             }
+        }
+        if ($this->dbType === 'pgsql') {
+            $pdoConnection = "pgsql:host=$this->host;port=$this->port;dbname=$this->dbName";
         }
 
         try {
@@ -173,12 +180,21 @@ class DBI
         try {
             $statement = self::$dbi->prepare($insert_text);
             foreach ($keys as $no => $key) {
-                $statement->bindValue(":{$key}", $values[$no]);
+                $val = $values[$no];
+                if ($this->dbType === 'pgsql' && is_bool($val)) {
+                    $statement->bindValue(":{$key}", $val ? 'true' : 'false', PDO::PARAM_STR);
+                } else {
+                    $statement->bindValue(":{$key}", $val);
+                }
             }
 
             if ($statement->execute()) {
                 if ($this->dbType === 'mysql') {
                     $last_id = self::$dbi->lastInsertId();
+                }
+                if ($this->dbType === 'pgsql') {
+                    $sequence = "{$this->query}_{$identity}_seq";
+                    $last_id = self::$dbi->lastInsertId($sequence);
                 }
                 if ($this->dbType === 'sqlsrv') {
                     if (strlen($identity) > 0) {
@@ -213,6 +229,7 @@ class DBI
 
         $key_where = " WHERE ";
         foreach ($where as $key => $value) {
+            if ($this->dbType === 'pgsql' && is_bool($value)) $value = $value ? 1 : 0;
             $key_where .= "{$ticks}{$key}{$ticks} = '{$value}' AND ";
         }
         $key_where = substr($key_where, 0, -4);
@@ -257,9 +274,14 @@ class DBI
         try {
             $statement = self::$dbi->prepare($update_text);
             foreach ($data as $key => $val) {
-                $statement->bindValue(":{$key}", $val);
+                if ($this->dbType === 'pgsql' && is_bool($val)) {
+                    $statement->bindValue(":{$key}", $val ? 'true' : 'false', PDO::PARAM_STR);
+                } else {
+                    $statement->bindValue(":{$key}", $val);
+                }
             }
             foreach ($ids as $key => $val) {
+                if ($this->dbType === 'pgsql' && is_bool($val)) $val = $val ? 1 : 0;
                 $statement->bindValue(":{$key}", $val);
             }
             $result = $statement->execute();
@@ -443,6 +465,11 @@ class DBI
     private function _query_prepare_select(): string
     {
         return '?';
+    }
+
+    public static function _get_pdo_instance()
+    {
+        return self::$dbi;
     }
 
 }

--- a/src/plugins/DataTables.php
+++ b/src/plugins/DataTables.php
@@ -166,9 +166,13 @@ class DataTables
             return $this->response;
         }
 
+        $raw_for_count = $this->raw_query;
+        if ($this->db_engine === 'pgsql') {
+            $raw_for_count = preg_replace('/\s+ORDER\s+BY\s+[\s\S]+$/i', '', $this->raw_query);
+        }
         $count_sql = "SELECT ";
         $count_sql .= "COUNT(*) results ";
-        $count_sql .= "FROM ({$this->raw_query}) counter ";
+        $count_sql .= "FROM ({$raw_for_count}) counter ";
         $data = DBI::Prepare($count_sql, $this->database)->FirstRow();
         $this->records_total = intval($data['results']);
         $this->records_filtered = intval($data['results']);
@@ -177,7 +181,11 @@ class DataTables
             for ($i = 0; $i < count($this->column_names); $i++) {
                 //sql query workarounds for search single quotes
                 $st = str_replace("'", "\'", $this->search_terms);
-                $this->search_array[] = "{$this->column_names[$i]} LIKE '%{$st}%'";
+                if ($this->db_engine === 'pgsql') {
+                    $this->search_array[] = "CAST({$this->column_names[$i]} AS TEXT) ILIKE '%{$st}%'";
+                } else {
+                    $this->search_array[] = "{$this->column_names[$i]} LIKE '%{$st}%'";
+                }
             }
         }
 
@@ -217,6 +225,9 @@ class DataTables
         }
         if ($this->db_engine === 'sqlsrv') {
             $search_param .= " OFFSET {$this->start} ROWS FETCH NEXT {$this->length} ROWS ONLY";
+        }
+        if ($this->db_engine === 'pgsql') {
+            $search_param .= " LIMIT {$this->length} OFFSET {$this->start}";
         }
 
         $data = DBI::Prepare(


### PR DESCRIPTION
## Summary
Adds PostgreSQL support to the PDA layer (`DBI`) and the `DataTables` plugin.
All PostgreSQL-specific behavior is gated behind `dbType` / `db_engine === 'pgsql'`,
so MySQL and SQL Server code paths are unchanged — existing apps behave exactly as before.

## DBI (`src/pda/DBI.php`)
- New `pgsql` DSN branch: `pgsql:host=...;port=...;dbname=...`
- Bind PHP booleans as `'true'/'false'` (pgsql only)
- `lastInsertId` via `"{table}_{identity}_seq"` sequence (pgsql only)
- `DBISet()` falls back to `getenv('DB_*')` when a config key is absent (uses `isset()`, so empty / "0" config values are preserved — strict superset of previous behavior)
- Expose `DBI::_get_pdo_instance()`

## DataTables (`src/plugins/DataTables.php`)
- pgsql search via `CAST(col AS TEXT) ILIKE '%...%'`
- pgsql pagination via `LIMIT ... OFFSET ...`
- Strip `ORDER BY` before the `COUNT(*)` wrap (pgsql only)